### PR TITLE
Replace expiresInMinutes with expiresIn

### DIFF
--- a/AuthStarter/server/auth/auth.service.js
+++ b/AuthStarter/server/auth/auth.service.js
@@ -57,7 +57,7 @@ function hasRole(roleRequired) {
  * Returns a jwt token signed by the app secret
  */
 function signToken(id) {
-  return jwt.sign({ _id: id }, config.secrets.session, { expiresInMinutes: 60*5 });
+  return jwt.sign({ _id: id }, config.secrets.session, { expiresIn: 18000 });
 }
 
 /**


### PR DESCRIPTION
expiresInMinutes and expiresInSeconds have been deprecated in new version of JSON Web Token
