### PR TITLE
Replace expiresInMinutes with expiresIn

### DIFF
--- a/AuthStarter/server/api/user/user.controller.js
+++ b/AuthStarter/server/api/user/user.controller.js
@@ -29,7 +29,7 @@ exports.create = function (req, res, next) {
   newUser.role = 'user';
   newUser.save(function(err, user) {
     if (err) return validationError(res, err);
-    var token = jwt.sign({_id: user._id }, config.secrets.session, { expiresInMinutes: 60*5 });
+    var token = jwt.sign({_id: user._id }, config.secrets.session, { expiresIn: 18000 });
     res.json({ token: token });
   });
 };


### PR DESCRIPTION
expiresInMinutes and expiresInSeconds have been deprecated in the new version of JSON Web Token
